### PR TITLE
Remove byte order marks

### DIFF
--- a/2020/20200630__co__primary__county.csv
+++ b/2020/20200630__co__primary__county.csv
@@ -1,4 +1,4 @@
-﻿county,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 ADAMS,U.S. Senate,,Democratic Party,Andrew Romanoff,27254
 ALAMOSA,U.S. Senate,,Democratic Party,Andrew Romanoff,927
 ARAPAHOE,U.S. Senate,,Democratic Party,Andrew Romanoff,47231


### PR DESCRIPTION
This removes unnecessary byte order marks.  The two files are utf-8 compatible.
```
$ file -ib 2020/20200630__co__primary__county.csv 2020/20201103__co__general__precinct.csv
text/csv; charset=utf-8
text/csv; charset=us-ascii
```