### PR TITLE
Fix incorrect precinct in 2012 Grand County general file

### DIFF
--- a/2012/20121106__co__general__grand__precinct.csv
+++ b/2012/20121106__co__general__grand__precinct.csv
@@ -1,1 +1,508 @@
-county,precinct,office,district,party,candidate,mail_votes,early_votes,poll_votes,total_votesGrand,2081325001,President,,ACP,Virgil Goode,1,0,0,1Grand,2081325001,President,,DEM,Barack Obama,191,13,71,275Grand,2081325001,President,,REP,Mitt Romney,240,36,73,349Grand,2081325001,President,,LBT,Gary Johnson,1,0,1,2Grand,2081325001,President,,GRN,Jill Stein,0,0,0,0Grand,2081325001,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325001,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325001,President,,PFP,Roseanne Barr,1,0,2,3Grand,2081325001,President,,SWP,James Harris,0,0,0,0Grand,2081325001,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325001,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325001,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325001,President,,UNA,Jill Reed,0,0,0,0Grand,2081325001,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325001,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325001,President,,SEP,Jerry White,0,0,0,0Grand,2081325001,President,,,Write-in,0,0,0,0Grand,2081325001,President,,Voters,Over Vote,0,0,0,0Grand,2081325001,President,,Voters,Under Vote,1,0,0,1Grand,2081325001,President,,Voters,ballots,435,49,147,631Grand,2081325002,President,,ACP,Virgil Goode,0,0,0,0Grand,2081325002,President,,DEM,Barack Obama,222,33,78,333Grand,2081325002,President,,REP,Mitt Romney,368,59,143,570Grand,2081325002,President,,LBT,Gary Johnson,10,0,5,15Grand,2081325002,President,,GRN,Jill Stein,2,0,1,3Grand,2081325002,President,,SOC,Stewart Alexander,1,0,0,1Grand,2081325002,President,,JUS,Ross Anderson,2,0,0,2Grand,2081325002,President,,PFP,Roseanne Barr,0,1,1,2Grand,2081325002,President,,SWP,James Harris,0,0,0,0Grand,2081325002,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325002,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325002,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325002,President,,UNA,Jill Reed,1,0,0,1Grand,2081325002,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325002,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325002,President,,SEP,Jerry White,0,0,0,0Grand,2081325002,President,,,Write-in,0,0,0,0Grand,2081325002,President,,Voters,Over Vote,0,0,1,1Grand,2081325002,President,,Voters,Under Vote,4,0,4,8Grand,2081325002,President,,Voters,ballots,610,93,233,936Grand,2081325003,President,,ACP,Virgil Goode,6,0,2,8Grand,2081325003,President,,DEM,Barack Obama,330,33,95,458Grand,2081325003,President,,REP,Mitt Romney,378,49,149,576Grand,2081325003,President,,LBT,Gary Johnson,12,1,10,23Grand,2081325003,President,,GRN,Jill Stein,6,0,2,8Grand,2081325003,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325003,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325003,President,,PFP,Roseanne Barr,5,0,1,6Grand,2081325003,President,,SWP,James Harris,0,0,0,0Grand,2081325003,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325003,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325003,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325003,President,,UNA,Jill Reed,0,0,0,0Grand,2081325003,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325003,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325003,President,,SEP,Jerry White,0,0,0,0Grand,2081325003,President,,,Write-in,0,0,0,0Grand,2081325003,President,,Voters,Over Vote,1,0,0,1Grand,2081325003,President,,Voters,Under Vote,6,1,4,11Grand,2081325003,President,,Voters,ballots,744,84,263,1091Grand,2081325004,President,,ACP,Virgil Goode,2,0,0,2Grand,2081325004,President,,DEM,Barack Obama,80,16,42,138Grand,2081325004,President,,REP,Mitt Romney,209,28,120,357Grand,2081325004,President,,LBT,Gary Johnson,6,1,3,10Grand,2081325004,President,,GRN,Jill Stein,1,0,2,3Grand,2081325004,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325004,President,,JUS,Ross Anderson,1,0,0,1Grand,2081325004,President,,PFP,Roseanne Barr,0,0,1,1Grand,2081325004,President,,SWP,James Harris,0,0,0,0Grand,2081325004,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325004,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325004,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325004,President,,UNA,Jill Reed,1,0,0,1Grand,2081325004,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325004,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325004,President,,SEP,Jerry White,0,0,0,0Grand,2081325004,President,,,Write-in,0,0,0,0Grand,2081325004,President,,Voters,Over Vote,0,0,0,0Grand,2081325004,President,,Voters,Under Vote,4,0,0,4Grand,2081325004,President,,Voters,ballots,304,45,168,517Grand,2081325005,President,,ACP,Virgil Goode,1,0,1,2Grand,2081325005,President,,DEM,Barack Obama,165,10,69,244Grand,2081325005,President,,REP,Mitt Romney,304,29,137,470Grand,2081325005,President,,LBT,Gary Johnson,10,1,4,15Grand,2081325005,President,,GRN,Jill Stein,2,0,1,3Grand,2081325005,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325005,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325005,President,,PFP,Roseanne Barr,1,0,2,3Grand,2081325005,President,,SWP,James Harris,0,0,0,0Grand,2081325005,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325005,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325005,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325005,President,,UNA,Jill Reed,1,0,0,1Grand,2081325005,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325005,President,,WTP,Sheila Tittle,1,0,0,1Grand,2081325005,President,,SEP,Jerry White,0,0,0,0Grand,2081325005,President,,,Write-in,0,0,0,0Grand,2081325005,President,,Voters,Over Vote,2,0,1,3Grand,2081325005,President,,Voters,Under Vote,4,0,1,5Grand,2081325005,President,,Voters,ballots,491,40,216,747Grand,2081325006,President,,ACP,Virgil Goode,0,0,0,0Grand,2081325006,President,,DEM,Barack Obama,178,12,104,294Grand,2081325006,President,,REP,Mitt Romney,117,5,52,174Grand,2081325006,President,,LBT,Gary Johnson,8,1,7,16Grand,2081325006,President,,GRN,Jill Stein,1,0,0,1Grand,2081325006,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325006,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325006,President,,PFP,Roseanne Barr,0,0,0,0Grand,2081325006,President,,SWP,James Harris,0,0,0,0Grand,2081325006,President,,AIP,Tom Hoefling,3,0,0,3Grand,2081325006,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325006,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325006,President,,UNA,Jill Reed,0,0,0,0Grand,2081325006,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325006,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325006,President,,SEP,Jerry White,0,0,0,0Grand,2081325006,President,,,Write-in,0,0,0,0Grand,2081325006,President,,Voters,Over Vote,0,0,0,0Grand,2081325006,President,,Voters,Under Vote,2,0,3,5Grand,2081325006,President,,Voters,ballots,309,18,166,493Grand,2081325007,President,,ACP,Virgil Goode,1,0,0,1Grand,2081325007,President,,DEM,Barack Obama,313,26,134,473Grand,2081325007,President,,REP,Mitt Romney,165,12,59,236Grand,2081325007,President,,LBT,Gary Johnson,9,0,9,18Grand,2081325007,President,,GRN,Jill Stein,3,0,2,5Grand,2081325007,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325007,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325007,President,,PFP,Roseanne Barr,1,0,0,1Grand,2081325007,President,,SWP,James Harris,0,0,0,0Grand,2081325007,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325007,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325007,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325007,President,,UNA,Jill Reed,0,0,0,0Grand,2081325007,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325007,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325007,President,,SEP,Jerry White,0,0,0,0Grand,2081325007,President,,,Write-in,0,0,0,0Grand,2081325007,President,,Voters,Over Vote,0,0,0,0Grand,2081325007,President,,Voters,Under Vote,3,0,2,5Grand,2081325007,President,,Voters,ballots,495,38,206,739Grand,2081325008,President,,ACP,Virgil Goode,1,3,3,7Grand,2081325008,President,,DEM,Barack Obama,120,26,37,183Grand,2081325008,President,,REP,Mitt Romney,210,69,51,330Grand,2081325008,President,,LBT,Gary Johnson,6,4,1,11Grand,2081325008,President,,GRN,Jill Stein,0,0,0,0Grand,2081325008,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325008,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325008,President,,PFP,Roseanne Barr,2,0,1,3Grand,2081325008,President,,SWP,James Harris,0,0,0,0Grand,2081325008,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325008,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325008,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325008,President,,UNA,Jill Reed,1,0,0,1Grand,2081325008,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325008,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325008,President,,SEP,Jerry White,0,0,0,0Grand,2081325008,President,,,Write-in,0,0,0,0Grand,2081325008,President,,Voters,Over Vote,0,0,0,0Grand,2081325008,President,,Voters,Under Vote,10,2,1,13Grand,2081325008,President,,Voters,ballots,350,104,94,548Grand,2081325009,President,,ACP,Virgil Goode,0,0,2,2Grand,2081325009,President,,DEM,Barack Obama,182,17,102,301Grand,2081325009,President,,REP,Mitt Romney,104,4,56,164Grand,2081325009,President,,LBT,Gary Johnson,6,0,7,13Grand,2081325009,President,,GRN,Jill Stein,0,1,0,1Grand,2081325009,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325009,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325009,President,,PFP,Roseanne Barr,0,0,0,0Grand,2081325009,President,,SWP,James Harris,0,0,0,0Grand,2081325009,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325009,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325009,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325009,President,,UNA,Jill Reed,0,0,0,0Grand,2081325009,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325009,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325009,President,,SEP,Jerry White,0,0,0,0Grand,2081325009,President,,,Write-in,0,0,0,0Grand,2081325009,President,,Voters,Over Vote,0,0,0,0Grand,2081325009,President,,Voters,Under Vote,1,0,1,2Grand,2081325009,President,,Voters,ballots,293,22,168,483Grand,2081325010,President,,ACP,Virgil Goode,0,0,0,0Grand,2081325010,President,,DEM,Barack Obama,198,12,47,257Grand,2081325010,President,,REP,Mitt Romney,268,33,68,369Grand,2081325010,President,,LBT,Gary Johnson,6,0,1,7Grand,2081325010,President,,GRN,Jill Stein,1,0,0,1Grand,2081325010,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325010,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325010,President,,PFP,Roseanne Barr,0,0,0,0Grand,2081325010,President,,SWP,James Harris,0,0,0,0Grand,2081325010,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325010,President,,SAL,Gloria La Riva,1,0,0,1Grand,2081325010,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325010,President,,UNA,Jill Reed,1,0,0,1Grand,2081325010,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325010,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325010,President,,SEP,Jerry White,0,0,0,0Grand,2081325010,President,,,Write-in,0,0,0,0Grand,2081325010,President,,Voters,Over Vote,2,0,1,3Grand,2081325010,President,,Voters,Under Vote,1,0,1,2Grand,2081325010,President,,Voters,ballots,478,45,118,641Grand,2081325011,President,,ACP,Virgil Goode,1,0,0,1Grand,2081325011,President,,DEM,Barack Obama,206,19,67,292Grand,2081325011,President,,REP,Mitt Romney,126,15,54,195Grand,2081325011,President,,LBT,Gary Johnson,4,0,2,6Grand,2081325011,President,,GRN,Jill Stein,0,0,2,2Grand,2081325011,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325011,President,,JUS,Ross Anderson,3,0,0,3Grand,2081325011,President,,PFP,Roseanne Barr,0,0,0,0Grand,2081325011,President,,SWP,James Harris,0,0,0,0Grand,2081325011,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325011,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325011,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325011,President,,UNA,Jill Reed,0,0,0,0Grand,2081325011,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325011,President,,WTP,Sheila Tittle,0,0,1,1Grand,2081325011,President,,SEP,Jerry White,0,0,0,0Grand,2081325011,President,,,Write-in,0,0,0,0Grand,2081325011,President,,Voters,Over Vote,1,0,0,1Grand,2081325011,President,,Voters,Under Vote,3,0,2,5Grand,2081325011,President,,Voters,ballots,344,34,128,506Grand,2081325012,President,,ACP,Virgil Goode,1,0,0,1Grand,2081325012,President,,DEM,Barack Obama,245,19,91,355Grand,2081325012,President,,REP,Mitt Romney,293,17,80,390Grand,2081325012,President,,LBT,Gary Johnson,8,0,6,14Grand,2081325012,President,,GRN,Jill Stein,1,0,1,2Grand,2081325012,President,,SOC,Stewart Alexander,0,0,0,0Grand,2081325012,President,,JUS,Ross Anderson,0,0,0,0Grand,2081325012,President,,PFP,Roseanne Barr,0,0,0,0Grand,2081325012,President,,SWP,James Harris,0,0,0,0Grand,2081325012,President,,AIP,Tom Hoefling,0,0,0,0Grand,2081325012,President,,SAL,Gloria La Riva,0,0,0,0Grand,2081325012,President,,ATP,Merlin Miller,0,0,0,0Grand,2081325012,President,,UNA,Jill Reed,0,0,0,0Grand,2081325012,President,,OBJ,Thomas Stevens,0,0,0,0Grand,2081325012,President,,WTP,Sheila Tittle,0,0,0,0Grand,2081325012,President,,SEP,Jerry White,0,0,0,0Grand,2081325012,President,,,Write-in,0,0,0,0Grand,2081325012,President,,Voters,Over Vote,0,0,0,0Grand,2081325012,President,,Voters,Under Vote,9,0,1,10Grand,2081325012,President,,Voters,ballots,557,36,179,772Grand,Prov,President,,ACP,Virgil Goode,,,1,26Grand,Prov,President,,DEM,Barack Obama,,,81,3684Grand,Prov,President,,REP,Mitt Romney,,,73,4253Grand,Prov,President,,LBT,Gary Johnson,,,5,155Grand,Prov,President,,GRN,Jill Stein,,,1,30Grand,Prov,President,,SOC,Stewart Alexander,,,0,1Grand,Prov,President,,JUS,Ross Anderson,,,0,6Grand,Prov,President,,PFP,Roseanne Barr,,,2,21Grand,Prov,President,,SWP,James Harris,,,0,0Grand,Prov,President,,AIP,Tom Hoefling,,,0,3Grand,Prov,President,,SAL,Gloria La Riva,,,0,1Grand,Prov,President,,ATP,Merlin Miller,,,0,0Grand,Prov,President,,UNA,Jill Reed,,,0,5Grand,Prov,President,,OBJ,Thomas Stevens,,,0,0Grand,Prov,President,,WTP,Sheila Tittle,,,0,2Grand,Prov,President,,SEP,Jerry White,,,0,0Grand,Prov,President,,,Write-in,,,0,0Grand,Prov,President,,Voters,Over Vote,,,1,10Grand,Prov,President,,Voters,Under Vote,,,2,73Grand,Prov,President,,Voters,Ballots,,,166,8270Grand,2081325001,U.S. House,2,REP,Kevin Lundberg,223,34,68,325Grand,2081325001,U.S. House,2,DEM,Jared Polis,178,12,64,254Grand,2081325001,U.S. House,2,LBT,Randy Luallin,6,1,2,9Grand,2081325001,U.S. House,2,GRN,Susan P. Hall,12,1,4,17Grand,2081325001,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325001,U.S. House,2,Voters,Under Vote,16,1,9,26Grand,2081325001,U.S. House,2,Voters,Number of Ballots,435,49,147,631Grand,2081325002,U.S. House,2,REP,Kevin Lundberg,339,58,126,523Grand,2081325002,U.S. House,2,DEM,Jared Polis,194,32,71,297Grand,2081325002,U.S. House,2,LBT,Randy Luallin,15,0,6,21Grand,2081325002,U.S. House,2,GRN,Susan P. Hall,13,0,6,19Grand,2081325002,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325002,U.S. House,2,Voters,Under Vote,49,3,24,76Grand,2081325002,U.S. House,2,Voters,Number of Ballots,610,93,233,936Grand,2081325003,U.S. House,2,REP,Kevin Lundberg,351,40,138,529Grand,2081325003,U.S. House,2,DEM,Jared Polis,308,30,82,420Grand,2081325003,U.S. House,2,LBT,Randy Luallin,15,5,14,34Grand,2081325003,U.S. House,2,GRN,Susan P. Hall,16,5,7,28Grand,2081325003,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325003,U.S. House,2,Voters,Under Vote,54,4,22,80Grand,2081325003,U.S. House,2,Voters,Number of Ballots,744,84,263,1091Grand,2081325004,U.S. House,2,REP,Kevin Lundberg,194,27,118,339Grand,2081325004,U.S. House,2,DEM,Jared Polis,68,16,34,118Grand,2081325004,U.S. House,2,LBT,Randy Luallin,16,1,5,22Grand,2081325004,U.S. House,2,GRN,Susan P. Hall,11,0,2,13Grand,2081325004,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325004,U.S. House,2,Voters,Under Vote,15,1,9,25Grand,2081325004,U.S. House,2,Voters,Number of Ballots,304,45,168,517Grand,2081325005,U.S. House,2,REP,Kevin Lundberg,304,28,125,457Grand,2081325005,U.S. House,2,DEM,Jared Polis,142,11,65,218Grand,2081325005,U.S. House,2,LBT,Randy Luallin,14,0,4,18Grand,2081325005,U.S. House,2,GRN,Susan P. Hall,9,0,8,17Grand,2081325005,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325005,U.S. House,2,Voters,Under Vote,22,1,14,37Grand,2081325005,U.S. House,2,Voters,Number of Ballots,491,40,216,747Grand,2081325006,U.S. House,2,REP,Kevin Lundberg,112,4,43,159Grand,2081325006,U.S. House,2,DEM,Jared Polis,148,12,79,239Grand,2081325006,U.S. House,2,LBT,Randy Luallin,14,2,8,24Grand,2081325006,U.S. House,2,GRN,Susan P. Hall,6,0,8,14Grand,2081325006,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325006,U.S. House,2,Voters,Under Vote,29,0,28,57Grand,2081325006,U.S. House,2,Voters,Number of Ballots,309,18,166,493Grand,2081325007,U.S. House,2,REP,Kevin Lundberg,153,9,55,217Grand,2081325007,U.S. House,2,DEM,Jared Polis,287,23,104,414Grand,2081325007,U.S. House,2,LBT,Randy Luallin,16,3,14,33Grand,2081325007,U.S. House,2,GRN,Susan P. Hall,13,1,16,30Grand,2081325007,U.S. House,2,Voters,Over Vote,0,0,1,1Grand,2081325007,U.S. House,2,Voters,Under Vote,26,2,16,44Grand,2081325007,U.S. House,2,Voters,Number of Ballots,495,38,206,739Grand,2081325008,U.S. House,2,REP,Kevin Lundberg,192,65,53,310Grand,2081325008,U.S. House,2,DEM,Jared Polis,111,24,28,163Grand,2081325008,U.S. House,2,LBT,Randy Luallin,14,5,5,24Grand,2081325008,U.S. House,2,GRN,Susan P. Hall,3,1,1,5Grand,2081325008,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325008,U.S. House,2,Voters,Under Vote,30,9,7,46Grand,2081325008,U.S. House,2,Voters,Number of Ballots,350,104,94,548Grand,2081325009,U.S. House,2,REP,Kevin Lundberg,91,2,56,149Grand,2081325009,U.S. House,2,DEM,Jared Polis,156,16,83,255Grand,2081325009,U.S. House,2,LBT,Randy Luallin,14,1,6,21Grand,2081325009,U.S. House,2,GRN,Susan P. Hall,8,3,10,21Grand,2081325009,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325009,U.S. House,2,Voters,Under Vote,24,0,13,37Grand,2081325009,U.S. House,2,Voters,Number of Ballots,293,22,168,483Grand,2081325010,U.S. House,2,REP,Kevin Lundberg,260,31,65,356Grand,2081325010,U.S. House,2,DEM,Jared Polis,177,12,39,228Grand,2081325010,U.S. House,2,LBT,Randy Luallin,7,1,4,12Grand,2081325010,U.S. House,2,GRN,Susan P. Hall,9,1,4,14Grand,2081325010,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325010,U.S. House,2,Voters,Under Vote,25,0,6,31Grand,2081325010,U.S. House,2,Voters,Number of Ballots,478,45,118,641Grand,2081325011,U.S. House,2,REP,Kevin Lundberg,123,14,54,191Grand,2081325011,U.S. House,2,DEM,Jared Polis,185,15,54,254Grand,2081325011,U.S. House,2,LBT,Randy Luallin,12,0,6,18Grand,2081325011,U.S. House,2,GRN,Susan P. Hall,4,2,5,11Grand,2081325011,U.S. House,2,Voters,Over Vote,1,0,0,1Grand,2081325011,U.S. House,2,Voters,Under Vote,19,3,9,31Grand,2081325011,U.S. House,2,Voters,Number of Ballots,344,34,128,506Grand,2081325012,U.S. House,2,REP,Kevin Lundberg,277,15,77,369Grand,2081325012,U.S. House,2,DEM,Jared Polis,229,20,75,324Grand,2081325012,U.S. House,2,LBT,Randy Luallin,9,0,5,14Grand,2081325012,U.S. House,2,GRN,Susan P. Hall,5,1,4,10Grand,2081325012,U.S. House,2,Voters,Over Vote,0,0,0,0Grand,2081325012,U.S. House,2,Voters,Under Vote,37,0,18,55Grand,2081325012,U.S. House,2,Voters,Number of Ballots,557,36,179,772Grand,Prov,U.S. House,2,REP,Kevin Lundberg,,,67,3991Grand,Prov,U.S. House,2,DEM,Jared Polis,,,65,3249Grand,Prov,U.S. House,2,LBT,Randy Luallin,,,12,262Grand,Prov,U.S. House,2,GRN,Susan P. Hall,,,11,210Grand,Prov,U.S. House,2,Voters,Over Vote,,,0,2Grand,Prov,U.S. House,2,Voters,Under Vote,,,11,556Grand,Prov,U.S. House,2,Voters,Number of Ballots,,,166,8270Grand,2081325001,State Senate,8,DEM,Emily Tracy,178,15,61,254Grand,2081325001,State Senate,8,REP,Randy L. Baumgardner,233,33,66,332Grand,2081325001,State Senate,8,LBT,Sacha L. Weis,9,0,9,18Grand,2081325001,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325001,State Senate,8,Voters,Under Vote,15,1,11,27Grand,2081325001,State Senate,8,Voters,Number of Ballots,435,49,147,631Grand,2081325001,State House,13,REP,Adam Ochs,220,34,67,321Grand,2081325001,State House,13,DEM,Claire Levy,179,13,67,259Grand,2081325001,State House,13,LBT,Howard P Lambert,10,1,3,14Grand,2081325001,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325001,State House,13,Voters,Under Vote,26,1,10,37Grand,2081325001,State House,13,Voters,Number of Ballots,435,49,147,631Grand,2081325002,State Senate,8,DEM,Emily Tracy,203,28,66,297Grand,2081325002,State Senate,8,REP,Randy L. Baumgardner,348,56,141,545Grand,2081325002,State Senate,8,LBT,Sacha L. Weis,26,5,10,41Grand,2081325002,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325002,State Senate,8,Voters,Under Vote,33,4,16,53Grand,2081325002,State Senate,8,Voters,Number of Ballots,610,93,233,936Grand,2081325002,State House,13,REP,Adam Ochs,342,52,124,518Grand,2081325002,State House,13,DEM,Claire Levy,190,30,67,287Grand,2081325002,State House,13,LBT,Howard P Lambert,25,3,17,45Grand,2081325002,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325002,State House,13,Voters,Under Vote,53,8,25,86Grand,2081325002,State House,13,Voters,Number of Ballots,610,93,233,936Grand,2081325003,State Senate,8,DEM,Emily Tracy,302,34,71,407Grand,2081325003,State Senate,8,REP,Randy L. Baumgardner,389,47,165,601Grand,2081325003,State Senate,8,LBT,Sacha L. Weis,22,1,19,42Grand,2081325003,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325003,State Senate,8,Voters,Under Vote,31,2,8,41Grand,2081325003,State Senate,8,Voters,Number of Ballots,744,84,263,1091Grand,2081325003,State House,13,REP,Adam Ochs,338,39,142,519Grand,2081325003,State House,13,DEM,Claire Levy,315,35,74,424Grand,2081325003,State House,13,LBT,Howard P Lambert,29,5,24,58Grand,2081325003,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325003,State House,13,Voters,Under Vote,62,5,23,90Grand,2081325003,State House,13,Voters,Number of Ballots,744,84,263,1091Grand,2081325003,State Senate,8,DEM,Emily Tracy,71,15,37,123Grand,2081325004,State Senate,8,REP,Randy L. Baumgardner,206,27,119,352Grand,2081325004,State Senate,8,LBT,Sacha L. Weis,14,1,6,21Grand,2081325004,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325004,State Senate,8,Voters,Under Vote,13,2,6,21Grand,2081325004,State Senate,8,Voters,Number of Ballots,304,45,168,517Grand,2081325004,State House,13,REP,Adam Ochs,195,29,105,329Grand,2081325004,State House,13,DEM,Claire Levy,67,14,41,122Grand,2081325004,State House,13,LBT,Howard P Lambert,18,1,10,29Grand,2081325004,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325004,State House,13,Voters,Under Vote,24,1,12,37Grand,2081325004,State House,13,Voters,Number of Ballots,304,45,168,517Grand,2081325005,State Senate,8,DEM,Emily Tracy,138,11,60,209Grand,2081325005,State Senate,8,REP,Randy L. Baumgardner,309,27,137,473Grand,2081325005,State Senate,8,LBT,Sacha L. Weis,18,1,6,25Grand,2081325005,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325005,State Senate,8,Voters,Under Vote,26,1,13,40Grand,2081325005,State Senate,8,Voters,Number of Ballots,491,40,216,747Grand,2081325005,State House,13,REP,Adam Ochs,306,30,131,467Grand,2081325005,State House,13,DEM,Claire Levy,143,10,59,212Grand,2081325005,State House,13,LBT,Howard P Lambert,17,0,10,27Grand,2081325005,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325005,State House,13,Voters,Under Vote,25,0,16,41Grand,2081325005,State House,13,Voters,Number of Ballots,491,40,216,747Grand,2081325006,State Senate,8,DEM,Emily Tracy,134,9,84,227Grand,2081325006,State Senate,8,REP,Randy L. Baumgardner,129,6,42,177Grand,2081325006,State Senate,8,LBT,Sacha L. Weis,21,2,12,35Grand,2081325006,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325006,State Senate,8,Voters,Under Vote,25,1,28,54Grand,2081325006,State Senate,8,Voters,Number of Ballots,309,18,166,493Grand,2081325006,State House,13,REP,Adam Ochs,114,5,42,161Grand,2081325006,State House,13,DEM,Claire Levy,147,11,85,243Grand,2081325006,State House,13,LBT,Howard P Lambert,17,2,10,29Grand,2081325006,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325006,State House,13,Voters,Under Vote,31,0,29,60Grand,2081325006,State House,13,Voters,Number of Ballots,309,18,166,493Grand,2081325007,State Senate,8,DEM,Emily Tracy,282,25,117,424Grand,2081325007,State Senate,8,REP,Randy L. Baumgardner,161,11,58,230Grand,2081325007,State Senate,8,LBT,Sacha L. Weis,22,1,11,34Grand,2081325007,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325007,State Senate,8,Voters,Under Vote,30,1,20,51Grand,2081325007,State Senate,8,Voters,Number of Ballots,495,38,206,739Grand,2081325007,State House,13,REP,Adam Ochs,155,9,54,218Grand,2081325007,State House,13,DEM,Claire Levy,283,25,109,417Grand,2081325007,State House,13,LBT,Howard P Lambert,25,3,16,44Grand,2081325007,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325007,State House,13,Voters,Under Vote,32,1,27,60Grand,2081325007,State House,13,Voters,Number of Ballots,495,38,206,739Grand,2081325008,State Senate,8,DEM,Emily Tracy,108,32,28,168Grand,2081325008,State Senate,8,REP,Randy L. Baumgardner,200,68,56,324Grand,2081325008,State Senate,8,LBT,Sacha L. Weis,21,3,7,31Grand,2081325008,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325008,State Senate,8,Voters,Under Vote,21,1,3,25Grand,2081325008,State Senate,8,Voters,Number of Ballots,350,104,94,548Grand,2081325008,State House,13,REP,Adam Ochs,199,66,46,311Grand,2081325008,State House,13,DEM,Claire Levy,94,22,31,147Grand,2081325008,State House,13,LBT,Howard P Lambert,17,8,8,33Grand,2081325008,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325008,State House,13,Voters,Under Vote,40,8,9,57Grand,2081325008,State House,13,Voters,Number of Ballots,350,104,94,548Grand,2081325009,State Senate,8,DEM,Emily Tracy,160,16,89,265Grand,2081325009,State Senate,8,REP,Randy L. Baumgardner,100,5,61,166Grand,2081325009,State Senate,8,LBT,Sacha L. Weis,15,1,7,23Grand,2081325009,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325009,State Senate,8,Voters,Under Vote,18,0,11,29Grand,2081325009,State Senate,8,Voters,Number of Ballots,293,22,168,483Grand,2081325009,State House,13,REP,Adam Ochs,98,5,49,152Grand,2081325009,State House,13,DEM,Claire Levy,156,14,95,265Grand,2081325009,State House,13,LBT,Howard P Lambert,15,2,7,24Grand,2081325009,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325009,State House,13,Voters,Under Vote,24,1,17,42Grand,2081325009,State House,13,Voters,Number of Ballots,293,22,168,483Grand,2081325010,State Senate,8,DEM,Emily Tracy,180,14,41,235Grand,2081325010,State Senate,8,REP,Randy L. Baumgardner,266,30,73,369Grand,2081325010,State Senate,8,LBT,Sacha L. Weis,10,1,2,13Grand,2081325010,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325010,State Senate,8,Voters,Under Vote,22,0,2,24Grand,2081325010,State Senate,8,Voters,Number of Ballots,478,45,118,641Grand,2081325010,State House,13,REP,Adam Ochs,253,29,65,347Grand,2081325010,State House,13,DEM,Claire Levy,183,13,44,240Grand,2081325010,State House,13,LBT,Howard P Lambert,11,2,5,18Grand,2081325010,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325010,State House,13,Voters,Under Vote,31,1,4,36Grand,2081325010,State House,13,Voters,Number of Ballots,478,45,118,641Grand,2081325011,State Senate,8,DEM,Emily Tracy,173,19,56,248Grand,2081325011,State Senate,8,REP,Randy L. Baumgardner,126,14,54,194Grand,2081325011,State Senate,8,LBT,Sacha L. Weis,26,0,9,35Grand,2081325011,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325011,State Senate,8,Voters,Under Vote,19,1,9,29Grand,2081325011,State Senate,8,Voters,Number of Ballots,344,34,128,506Grand,2081325011,State House,13,REP,Adam Ochs,124,13,49,186Grand,2081325011,State House,13,DEM,Claire Levy,172,18,57,247Grand,2081325011,State House,13,LBT,Howard P Lambert,19,0,12,31Grand,2081325011,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325011,State House,13,Voters,Under Vote,29,3,10,42Grand,2081325011,State House,13,Voters,Number of Ballots,344,34,128,506Grand,2081325012,State Senate,8,DEM,Emily Tracy,225,16,65,306Grand,2081325012,State Senate,8,REP,Randy L. Baumgardner,288,16,88,392Grand,2081325012,State Senate,8,LBT,Sacha L. Weis,17,4,7,28Grand,2081325012,State Senate,8,Voters,Over Vote,0,0,0,0Grand,2081325012,State Senate,8,Voters,Under Vote,27,0,19,46Grand,2081325012,State Senate,8,Voters,Number of Ballots,557,36,179,772Grand,2081325012,State House,13,REP,Adam Ochs,276,15,77,368Grand,2081325012,State House,13,DEM,Claire Levy,226,17,69,312Grand,2081325012,State House,13,LBT,Howard P Lambert,13,2,11,26Grand,2081325012,State House,13,Voters,Over Vote,0,0,0,0Grand,2081325012,State House,13,Voters,Under Vote,42,2,22,66Grand,2081325012,State House,13,Voters,Number of Ballots,557,36,179,772Grand,Prov,State Senate,8,DEM,Emily Tracy,,,62,"3,225"Grand,Prov,State Senate,8,REP,Randy L. Baumgardner,,,69,"4,224"Grand,Prov,State Senate,8,LBT,Sacha L. Weis,,,10,356Grand,Prov,State Senate,8,Voters,Over Vote,,,0,0Grand,Prov,State Senate,8,Voters,Under Vote,,,25,465Grand,Prov,State Senate,8,Voters,Number of Ballots,,,166,"8,270"Grand,Prov,State House,13,REP,Adam Ochs,,,58,"3,955"Grand,Prov,State House,13,DEM,Claire Levy,,,64,"3,239"Grand,Prov,State House,13,LBT,Howard P Lambert,,,15,393Grand,Prov,State House,13,Voters,Over Vote,,,0,0Grand,Prov,State House,13,Voters,Under Vote,,,29,683Grand,Prov,State House,13,Voters,Number of Ballots,,,166,"8,270"
+county,precinct,office,district,party,candidate,mail_votes,early_votes,poll_votes,total_votes
+Grand,2081325001,President,,ACP,Virgil Goode,1,0,0,1
+Grand,2081325001,President,,DEM,Barack Obama,191,13,71,275
+Grand,2081325001,President,,REP,Mitt Romney,240,36,73,349
+Grand,2081325001,President,,LBT,Gary Johnson,1,0,1,2
+Grand,2081325001,President,,GRN,Jill Stein,0,0,0,0
+Grand,2081325001,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325001,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325001,President,,PFP,Roseanne Barr,1,0,2,3
+Grand,2081325001,President,,SWP,James Harris,0,0,0,0
+Grand,2081325001,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325001,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325001,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325001,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325001,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325001,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325001,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325001,President,,,Write-in,0,0,0,0
+Grand,2081325001,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325001,President,,Voters,Under Vote,1,0,0,1
+Grand,2081325001,President,,Voters,ballots,435,49,147,631
+Grand,2081325002,President,,ACP,Virgil Goode,0,0,0,0
+Grand,2081325002,President,,DEM,Barack Obama,222,33,78,333
+Grand,2081325002,President,,REP,Mitt Romney,368,59,143,570
+Grand,2081325002,President,,LBT,Gary Johnson,10,0,5,15
+Grand,2081325002,President,,GRN,Jill Stein,2,0,1,3
+Grand,2081325002,President,,SOC,Stewart Alexander,1,0,0,1
+Grand,2081325002,President,,JUS,Ross Anderson,2,0,0,2
+Grand,2081325002,President,,PFP,Roseanne Barr,0,1,1,2
+Grand,2081325002,President,,SWP,James Harris,0,0,0,0
+Grand,2081325002,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325002,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325002,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325002,President,,UNA,Jill Reed,1,0,0,1
+Grand,2081325002,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325002,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325002,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325002,President,,,Write-in,0,0,0,0
+Grand,2081325002,President,,Voters,Over Vote,0,0,1,1
+Grand,2081325002,President,,Voters,Under Vote,4,0,4,8
+Grand,2081325002,President,,Voters,ballots,610,93,233,936
+Grand,2081325003,President,,ACP,Virgil Goode,6,0,2,8
+Grand,2081325003,President,,DEM,Barack Obama,330,33,95,458
+Grand,2081325003,President,,REP,Mitt Romney,378,49,149,576
+Grand,2081325003,President,,LBT,Gary Johnson,12,1,10,23
+Grand,2081325003,President,,GRN,Jill Stein,6,0,2,8
+Grand,2081325003,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325003,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325003,President,,PFP,Roseanne Barr,5,0,1,6
+Grand,2081325003,President,,SWP,James Harris,0,0,0,0
+Grand,2081325003,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325003,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325003,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325003,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325003,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325003,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325003,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325003,President,,,Write-in,0,0,0,0
+Grand,2081325003,President,,Voters,Over Vote,1,0,0,1
+Grand,2081325003,President,,Voters,Under Vote,6,1,4,11
+Grand,2081325003,President,,Voters,ballots,744,84,263,1091
+Grand,2081325004,President,,ACP,Virgil Goode,2,0,0,2
+Grand,2081325004,President,,DEM,Barack Obama,80,16,42,138
+Grand,2081325004,President,,REP,Mitt Romney,209,28,120,357
+Grand,2081325004,President,,LBT,Gary Johnson,6,1,3,10
+Grand,2081325004,President,,GRN,Jill Stein,1,0,2,3
+Grand,2081325004,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325004,President,,JUS,Ross Anderson,1,0,0,1
+Grand,2081325004,President,,PFP,Roseanne Barr,0,0,1,1
+Grand,2081325004,President,,SWP,James Harris,0,0,0,0
+Grand,2081325004,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325004,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325004,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325004,President,,UNA,Jill Reed,1,0,0,1
+Grand,2081325004,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325004,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325004,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325004,President,,,Write-in,0,0,0,0
+Grand,2081325004,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325004,President,,Voters,Under Vote,4,0,0,4
+Grand,2081325004,President,,Voters,ballots,304,45,168,517
+Grand,2081325005,President,,ACP,Virgil Goode,1,0,1,2
+Grand,2081325005,President,,DEM,Barack Obama,165,10,69,244
+Grand,2081325005,President,,REP,Mitt Romney,304,29,137,470
+Grand,2081325005,President,,LBT,Gary Johnson,10,1,4,15
+Grand,2081325005,President,,GRN,Jill Stein,2,0,1,3
+Grand,2081325005,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325005,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325005,President,,PFP,Roseanne Barr,1,0,2,3
+Grand,2081325005,President,,SWP,James Harris,0,0,0,0
+Grand,2081325005,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325005,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325005,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325005,President,,UNA,Jill Reed,1,0,0,1
+Grand,2081325005,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325005,President,,WTP,Sheila Tittle,1,0,0,1
+Grand,2081325005,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325005,President,,,Write-in,0,0,0,0
+Grand,2081325005,President,,Voters,Over Vote,2,0,1,3
+Grand,2081325005,President,,Voters,Under Vote,4,0,1,5
+Grand,2081325005,President,,Voters,ballots,491,40,216,747
+Grand,2081325006,President,,ACP,Virgil Goode,0,0,0,0
+Grand,2081325006,President,,DEM,Barack Obama,178,12,104,294
+Grand,2081325006,President,,REP,Mitt Romney,117,5,52,174
+Grand,2081325006,President,,LBT,Gary Johnson,8,1,7,16
+Grand,2081325006,President,,GRN,Jill Stein,1,0,0,1
+Grand,2081325006,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325006,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325006,President,,PFP,Roseanne Barr,0,0,0,0
+Grand,2081325006,President,,SWP,James Harris,0,0,0,0
+Grand,2081325006,President,,AIP,Tom Hoefling,3,0,0,3
+Grand,2081325006,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325006,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325006,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325006,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325006,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325006,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325006,President,,,Write-in,0,0,0,0
+Grand,2081325006,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325006,President,,Voters,Under Vote,2,0,3,5
+Grand,2081325006,President,,Voters,ballots,309,18,166,493
+Grand,2081325007,President,,ACP,Virgil Goode,1,0,0,1
+Grand,2081325007,President,,DEM,Barack Obama,313,26,134,473
+Grand,2081325007,President,,REP,Mitt Romney,165,12,59,236
+Grand,2081325007,President,,LBT,Gary Johnson,9,0,9,18
+Grand,2081325007,President,,GRN,Jill Stein,3,0,2,5
+Grand,2081325007,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325007,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325007,President,,PFP,Roseanne Barr,1,0,0,1
+Grand,2081325007,President,,SWP,James Harris,0,0,0,0
+Grand,2081325007,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325007,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325007,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325007,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325007,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325007,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325007,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325007,President,,,Write-in,0,0,0,0
+Grand,2081325007,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325007,President,,Voters,Under Vote,3,0,2,5
+Grand,2081325007,President,,Voters,ballots,495,38,206,739
+Grand,2081325008,President,,ACP,Virgil Goode,1,3,3,7
+Grand,2081325008,President,,DEM,Barack Obama,120,26,37,183
+Grand,2081325008,President,,REP,Mitt Romney,210,69,51,330
+Grand,2081325008,President,,LBT,Gary Johnson,6,4,1,11
+Grand,2081325008,President,,GRN,Jill Stein,0,0,0,0
+Grand,2081325008,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325008,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325008,President,,PFP,Roseanne Barr,2,0,1,3
+Grand,2081325008,President,,SWP,James Harris,0,0,0,0
+Grand,2081325008,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325008,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325008,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325008,President,,UNA,Jill Reed,1,0,0,1
+Grand,2081325008,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325008,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325008,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325008,President,,,Write-in,0,0,0,0
+Grand,2081325008,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325008,President,,Voters,Under Vote,10,2,1,13
+Grand,2081325008,President,,Voters,ballots,350,104,94,548
+Grand,2081325009,President,,ACP,Virgil Goode,0,0,2,2
+Grand,2081325009,President,,DEM,Barack Obama,182,17,102,301
+Grand,2081325009,President,,REP,Mitt Romney,104,4,56,164
+Grand,2081325009,President,,LBT,Gary Johnson,6,0,7,13
+Grand,2081325009,President,,GRN,Jill Stein,0,1,0,1
+Grand,2081325009,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325009,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325009,President,,PFP,Roseanne Barr,0,0,0,0
+Grand,2081325009,President,,SWP,James Harris,0,0,0,0
+Grand,2081325009,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325009,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325009,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325009,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325009,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325009,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325009,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325009,President,,,Write-in,0,0,0,0
+Grand,2081325009,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325009,President,,Voters,Under Vote,1,0,1,2
+Grand,2081325009,President,,Voters,ballots,293,22,168,483
+Grand,2081325010,President,,ACP,Virgil Goode,0,0,0,0
+Grand,2081325010,President,,DEM,Barack Obama,198,12,47,257
+Grand,2081325010,President,,REP,Mitt Romney,268,33,68,369
+Grand,2081325010,President,,LBT,Gary Johnson,6,0,1,7
+Grand,2081325010,President,,GRN,Jill Stein,1,0,0,1
+Grand,2081325010,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325010,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325010,President,,PFP,Roseanne Barr,0,0,0,0
+Grand,2081325010,President,,SWP,James Harris,0,0,0,0
+Grand,2081325010,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325010,President,,SAL,Gloria La Riva,1,0,0,1
+Grand,2081325010,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325010,President,,UNA,Jill Reed,1,0,0,1
+Grand,2081325010,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325010,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325010,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325010,President,,,Write-in,0,0,0,0
+Grand,2081325010,President,,Voters,Over Vote,2,0,1,3
+Grand,2081325010,President,,Voters,Under Vote,1,0,1,2
+Grand,2081325010,President,,Voters,ballots,478,45,118,641
+Grand,2081325011,President,,ACP,Virgil Goode,1,0,0,1
+Grand,2081325011,President,,DEM,Barack Obama,206,19,67,292
+Grand,2081325011,President,,REP,Mitt Romney,126,15,54,195
+Grand,2081325011,President,,LBT,Gary Johnson,4,0,2,6
+Grand,2081325011,President,,GRN,Jill Stein,0,0,2,2
+Grand,2081325011,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325011,President,,JUS,Ross Anderson,3,0,0,3
+Grand,2081325011,President,,PFP,Roseanne Barr,0,0,0,0
+Grand,2081325011,President,,SWP,James Harris,0,0,0,0
+Grand,2081325011,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325011,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325011,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325011,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325011,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325011,President,,WTP,Sheila Tittle,0,0,1,1
+Grand,2081325011,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325011,President,,,Write-in,0,0,0,0
+Grand,2081325011,President,,Voters,Over Vote,1,0,0,1
+Grand,2081325011,President,,Voters,Under Vote,3,0,2,5
+Grand,2081325011,President,,Voters,ballots,344,34,128,506
+Grand,2081325012,President,,ACP,Virgil Goode,1,0,0,1
+Grand,2081325012,President,,DEM,Barack Obama,245,19,91,355
+Grand,2081325012,President,,REP,Mitt Romney,293,17,80,390
+Grand,2081325012,President,,LBT,Gary Johnson,8,0,6,14
+Grand,2081325012,President,,GRN,Jill Stein,1,0,1,2
+Grand,2081325012,President,,SOC,Stewart Alexander,0,0,0,0
+Grand,2081325012,President,,JUS,Ross Anderson,0,0,0,0
+Grand,2081325012,President,,PFP,Roseanne Barr,0,0,0,0
+Grand,2081325012,President,,SWP,James Harris,0,0,0,0
+Grand,2081325012,President,,AIP,Tom Hoefling,0,0,0,0
+Grand,2081325012,President,,SAL,Gloria La Riva,0,0,0,0
+Grand,2081325012,President,,ATP,Merlin Miller,0,0,0,0
+Grand,2081325012,President,,UNA,Jill Reed,0,0,0,0
+Grand,2081325012,President,,OBJ,Thomas Stevens,0,0,0,0
+Grand,2081325012,President,,WTP,Sheila Tittle,0,0,0,0
+Grand,2081325012,President,,SEP,Jerry White,0,0,0,0
+Grand,2081325012,President,,,Write-in,0,0,0,0
+Grand,2081325012,President,,Voters,Over Vote,0,0,0,0
+Grand,2081325012,President,,Voters,Under Vote,9,0,1,10
+Grand,2081325012,President,,Voters,ballots,557,36,179,772
+Grand,Prov,President,,ACP,Virgil Goode,,,1,26
+Grand,Prov,President,,DEM,Barack Obama,,,81,3684
+Grand,Prov,President,,REP,Mitt Romney,,,73,4253
+Grand,Prov,President,,LBT,Gary Johnson,,,5,155
+Grand,Prov,President,,GRN,Jill Stein,,,1,30
+Grand,Prov,President,,SOC,Stewart Alexander,,,0,1
+Grand,Prov,President,,JUS,Ross Anderson,,,0,6
+Grand,Prov,President,,PFP,Roseanne Barr,,,2,21
+Grand,Prov,President,,SWP,James Harris,,,0,0
+Grand,Prov,President,,AIP,Tom Hoefling,,,0,3
+Grand,Prov,President,,SAL,Gloria La Riva,,,0,1
+Grand,Prov,President,,ATP,Merlin Miller,,,0,0
+Grand,Prov,President,,UNA,Jill Reed,,,0,5
+Grand,Prov,President,,OBJ,Thomas Stevens,,,0,0
+Grand,Prov,President,,WTP,Sheila Tittle,,,0,2
+Grand,Prov,President,,SEP,Jerry White,,,0,0
+Grand,Prov,President,,,Write-in,,,0,0
+Grand,Prov,President,,Voters,Over Vote,,,1,10
+Grand,Prov,President,,Voters,Under Vote,,,2,73
+Grand,Prov,President,,Voters,Ballots,,,166,8270
+Grand,2081325001,U.S. House,2,REP,Kevin Lundberg,223,34,68,325
+Grand,2081325001,U.S. House,2,DEM,Jared Polis,178,12,64,254
+Grand,2081325001,U.S. House,2,LBT,Randy Luallin,6,1,2,9
+Grand,2081325001,U.S. House,2,GRN,Susan P. Hall,12,1,4,17
+Grand,2081325001,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325001,U.S. House,2,Voters,Under Vote,16,1,9,26
+Grand,2081325001,U.S. House,2,Voters,Number of Ballots,435,49,147,631
+Grand,2081325002,U.S. House,2,REP,Kevin Lundberg,339,58,126,523
+Grand,2081325002,U.S. House,2,DEM,Jared Polis,194,32,71,297
+Grand,2081325002,U.S. House,2,LBT,Randy Luallin,15,0,6,21
+Grand,2081325002,U.S. House,2,GRN,Susan P. Hall,13,0,6,19
+Grand,2081325002,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325002,U.S. House,2,Voters,Under Vote,49,3,24,76
+Grand,2081325002,U.S. House,2,Voters,Number of Ballots,610,93,233,936
+Grand,2081325003,U.S. House,2,REP,Kevin Lundberg,351,40,138,529
+Grand,2081325003,U.S. House,2,DEM,Jared Polis,308,30,82,420
+Grand,2081325003,U.S. House,2,LBT,Randy Luallin,15,5,14,34
+Grand,2081325003,U.S. House,2,GRN,Susan P. Hall,16,5,7,28
+Grand,2081325003,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325003,U.S. House,2,Voters,Under Vote,54,4,22,80
+Grand,2081325003,U.S. House,2,Voters,Number of Ballots,744,84,263,1091
+Grand,2081325004,U.S. House,2,REP,Kevin Lundberg,194,27,118,339
+Grand,2081325004,U.S. House,2,DEM,Jared Polis,68,16,34,118
+Grand,2081325004,U.S. House,2,LBT,Randy Luallin,16,1,5,22
+Grand,2081325004,U.S. House,2,GRN,Susan P. Hall,11,0,2,13
+Grand,2081325004,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325004,U.S. House,2,Voters,Under Vote,15,1,9,25
+Grand,2081325004,U.S. House,2,Voters,Number of Ballots,304,45,168,517
+Grand,2081325005,U.S. House,2,REP,Kevin Lundberg,304,28,125,457
+Grand,2081325005,U.S. House,2,DEM,Jared Polis,142,11,65,218
+Grand,2081325005,U.S. House,2,LBT,Randy Luallin,14,0,4,18
+Grand,2081325005,U.S. House,2,GRN,Susan P. Hall,9,0,8,17
+Grand,2081325005,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325005,U.S. House,2,Voters,Under Vote,22,1,14,37
+Grand,2081325005,U.S. House,2,Voters,Number of Ballots,491,40,216,747
+Grand,2081325006,U.S. House,2,REP,Kevin Lundberg,112,4,43,159
+Grand,2081325006,U.S. House,2,DEM,Jared Polis,148,12,79,239
+Grand,2081325006,U.S. House,2,LBT,Randy Luallin,14,2,8,24
+Grand,2081325006,U.S. House,2,GRN,Susan P. Hall,6,0,8,14
+Grand,2081325006,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325006,U.S. House,2,Voters,Under Vote,29,0,28,57
+Grand,2081325006,U.S. House,2,Voters,Number of Ballots,309,18,166,493
+Grand,2081325007,U.S. House,2,REP,Kevin Lundberg,153,9,55,217
+Grand,2081325007,U.S. House,2,DEM,Jared Polis,287,23,104,414
+Grand,2081325007,U.S. House,2,LBT,Randy Luallin,16,3,14,33
+Grand,2081325007,U.S. House,2,GRN,Susan P. Hall,13,1,16,30
+Grand,2081325007,U.S. House,2,Voters,Over Vote,0,0,1,1
+Grand,2081325007,U.S. House,2,Voters,Under Vote,26,2,16,44
+Grand,2081325007,U.S. House,2,Voters,Number of Ballots,495,38,206,739
+Grand,2081325008,U.S. House,2,REP,Kevin Lundberg,192,65,53,310
+Grand,2081325008,U.S. House,2,DEM,Jared Polis,111,24,28,163
+Grand,2081325008,U.S. House,2,LBT,Randy Luallin,14,5,5,24
+Grand,2081325008,U.S. House,2,GRN,Susan P. Hall,3,1,1,5
+Grand,2081325008,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325008,U.S. House,2,Voters,Under Vote,30,9,7,46
+Grand,2081325008,U.S. House,2,Voters,Number of Ballots,350,104,94,548
+Grand,2081325009,U.S. House,2,REP,Kevin Lundberg,91,2,56,149
+Grand,2081325009,U.S. House,2,DEM,Jared Polis,156,16,83,255
+Grand,2081325009,U.S. House,2,LBT,Randy Luallin,14,1,6,21
+Grand,2081325009,U.S. House,2,GRN,Susan P. Hall,8,3,10,21
+Grand,2081325009,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325009,U.S. House,2,Voters,Under Vote,24,0,13,37
+Grand,2081325009,U.S. House,2,Voters,Number of Ballots,293,22,168,483
+Grand,2081325010,U.S. House,2,REP,Kevin Lundberg,260,31,65,356
+Grand,2081325010,U.S. House,2,DEM,Jared Polis,177,12,39,228
+Grand,2081325010,U.S. House,2,LBT,Randy Luallin,7,1,4,12
+Grand,2081325010,U.S. House,2,GRN,Susan P. Hall,9,1,4,14
+Grand,2081325010,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325010,U.S. House,2,Voters,Under Vote,25,0,6,31
+Grand,2081325010,U.S. House,2,Voters,Number of Ballots,478,45,118,641
+Grand,2081325011,U.S. House,2,REP,Kevin Lundberg,123,14,54,191
+Grand,2081325011,U.S. House,2,DEM,Jared Polis,185,15,54,254
+Grand,2081325011,U.S. House,2,LBT,Randy Luallin,12,0,6,18
+Grand,2081325011,U.S. House,2,GRN,Susan P. Hall,4,2,5,11
+Grand,2081325011,U.S. House,2,Voters,Over Vote,1,0,0,1
+Grand,2081325011,U.S. House,2,Voters,Under Vote,19,3,9,31
+Grand,2081325011,U.S. House,2,Voters,Number of Ballots,344,34,128,506
+Grand,2081325012,U.S. House,2,REP,Kevin Lundberg,277,15,77,369
+Grand,2081325012,U.S. House,2,DEM,Jared Polis,229,20,75,324
+Grand,2081325012,U.S. House,2,LBT,Randy Luallin,9,0,5,14
+Grand,2081325012,U.S. House,2,GRN,Susan P. Hall,5,1,4,10
+Grand,2081325012,U.S. House,2,Voters,Over Vote,0,0,0,0
+Grand,2081325012,U.S. House,2,Voters,Under Vote,37,0,18,55
+Grand,2081325012,U.S. House,2,Voters,Number of Ballots,557,36,179,772
+Grand,Prov,U.S. House,2,REP,Kevin Lundberg,,,67,3991
+Grand,Prov,U.S. House,2,DEM,Jared Polis,,,65,3249
+Grand,Prov,U.S. House,2,LBT,Randy Luallin,,,12,262
+Grand,Prov,U.S. House,2,GRN,Susan P. Hall,,,11,210
+Grand,Prov,U.S. House,2,Voters,Over Vote,,,0,2
+Grand,Prov,U.S. House,2,Voters,Under Vote,,,11,556
+Grand,Prov,U.S. House,2,Voters,Number of Ballots,,,166,8270
+Grand,2081325001,State Senate,8,DEM,Emily Tracy,178,15,61,254
+Grand,2081325001,State Senate,8,REP,Randy L. Baumgardner,233,33,66,332
+Grand,2081325001,State Senate,8,LBT,Sacha L. Weis,9,0,9,18
+Grand,2081325001,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325001,State Senate,8,Voters,Under Vote,15,1,11,27
+Grand,2081325001,State Senate,8,Voters,Number of Ballots,435,49,147,631
+Grand,2081325001,State House,13,REP,Adam Ochs,220,34,67,321
+Grand,2081325001,State House,13,DEM,Claire Levy,179,13,67,259
+Grand,2081325001,State House,13,LBT,Howard P Lambert,10,1,3,14
+Grand,2081325001,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325001,State House,13,Voters,Under Vote,26,1,10,37
+Grand,2081325001,State House,13,Voters,Number of Ballots,435,49,147,631
+Grand,2081325002,State Senate,8,DEM,Emily Tracy,203,28,66,297
+Grand,2081325002,State Senate,8,REP,Randy L. Baumgardner,348,56,141,545
+Grand,2081325002,State Senate,8,LBT,Sacha L. Weis,26,5,10,41
+Grand,2081325002,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325002,State Senate,8,Voters,Under Vote,33,4,16,53
+Grand,2081325002,State Senate,8,Voters,Number of Ballots,610,93,233,936
+Grand,2081325002,State House,13,REP,Adam Ochs,342,52,124,518
+Grand,2081325002,State House,13,DEM,Claire Levy,190,30,67,287
+Grand,2081325002,State House,13,LBT,Howard P Lambert,25,3,17,45
+Grand,2081325002,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325002,State House,13,Voters,Under Vote,53,8,25,86
+Grand,2081325002,State House,13,Voters,Number of Ballots,610,93,233,936
+Grand,2081325003,State Senate,8,DEM,Emily Tracy,302,34,71,407
+Grand,2081325003,State Senate,8,REP,Randy L. Baumgardner,389,47,165,601
+Grand,2081325003,State Senate,8,LBT,Sacha L. Weis,22,1,19,42
+Grand,2081325003,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325003,State Senate,8,Voters,Under Vote,31,2,8,41
+Grand,2081325003,State Senate,8,Voters,Number of Ballots,744,84,263,1091
+Grand,2081325003,State House,13,REP,Adam Ochs,338,39,142,519
+Grand,2081325003,State House,13,DEM,Claire Levy,315,35,74,424
+Grand,2081325003,State House,13,LBT,Howard P Lambert,29,5,24,58
+Grand,2081325003,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325003,State House,13,Voters,Under Vote,62,5,23,90
+Grand,2081325003,State House,13,Voters,Number of Ballots,744,84,263,1091
+Grand,2081325003,State Senate,8,DEM,Emily Tracy,71,15,37,123
+Grand,2081325004,State Senate,8,REP,Randy L. Baumgardner,206,27,119,352
+Grand,2081325004,State Senate,8,LBT,Sacha L. Weis,14,1,6,21
+Grand,2081325004,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325004,State Senate,8,Voters,Under Vote,13,2,6,21
+Grand,2081325004,State Senate,8,Voters,Number of Ballots,304,45,168,517
+Grand,2081325004,State House,13,REP,Adam Ochs,195,29,105,329
+Grand,2081325004,State House,13,DEM,Claire Levy,67,14,41,122
+Grand,2081325004,State House,13,LBT,Howard P Lambert,18,1,10,29
+Grand,2081325004,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325004,State House,13,Voters,Under Vote,24,1,12,37
+Grand,2081325004,State House,13,Voters,Number of Ballots,304,45,168,517
+Grand,2081325005,State Senate,8,DEM,Emily Tracy,138,11,60,209
+Grand,2081325005,State Senate,8,REP,Randy L. Baumgardner,309,27,137,473
+Grand,2081325005,State Senate,8,LBT,Sacha L. Weis,18,1,6,25
+Grand,2081325005,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325005,State Senate,8,Voters,Under Vote,26,1,13,40
+Grand,2081325005,State Senate,8,Voters,Number of Ballots,491,40,216,747
+Grand,2081325005,State House,13,REP,Adam Ochs,306,30,131,467
+Grand,2081325005,State House,13,DEM,Claire Levy,143,10,59,212
+Grand,2081325005,State House,13,LBT,Howard P Lambert,17,0,10,27
+Grand,2081325005,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325005,State House,13,Voters,Under Vote,25,0,16,41
+Grand,2081325005,State House,13,Voters,Number of Ballots,491,40,216,747
+Grand,2081325006,State Senate,8,DEM,Emily Tracy,134,9,84,227
+Grand,2081325006,State Senate,8,REP,Randy L. Baumgardner,129,6,42,177
+Grand,2081325006,State Senate,8,LBT,Sacha L. Weis,21,2,12,35
+Grand,2081325006,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325006,State Senate,8,Voters,Under Vote,25,1,28,54
+Grand,2081325006,State Senate,8,Voters,Number of Ballots,309,18,166,493
+Grand,2081325006,State House,13,REP,Adam Ochs,114,5,42,161
+Grand,2081325006,State House,13,DEM,Claire Levy,147,11,85,243
+Grand,2081325006,State House,13,LBT,Howard P Lambert,17,2,10,29
+Grand,2081325006,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325006,State House,13,Voters,Under Vote,31,0,29,60
+Grand,2081325006,State House,13,Voters,Number of Ballots,309,18,166,493
+Grand,2081325007,State Senate,8,DEM,Emily Tracy,282,25,117,424
+Grand,2081325007,State Senate,8,REP,Randy L. Baumgardner,161,11,58,230
+Grand,2081325007,State Senate,8,LBT,Sacha L. Weis,22,1,11,34
+Grand,2081325007,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325007,State Senate,8,Voters,Under Vote,30,1,20,51
+Grand,2081325007,State Senate,8,Voters,Number of Ballots,495,38,206,739
+Grand,2081325007,State House,13,REP,Adam Ochs,155,9,54,218
+Grand,2081325007,State House,13,DEM,Claire Levy,283,25,109,417
+Grand,2081325007,State House,13,LBT,Howard P Lambert,25,3,16,44
+Grand,2081325007,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325007,State House,13,Voters,Under Vote,32,1,27,60
+Grand,2081325007,State House,13,Voters,Number of Ballots,495,38,206,739
+Grand,2081325008,State Senate,8,DEM,Emily Tracy,108,32,28,168
+Grand,2081325008,State Senate,8,REP,Randy L. Baumgardner,200,68,56,324
+Grand,2081325008,State Senate,8,LBT,Sacha L. Weis,21,3,7,31
+Grand,2081325008,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325008,State Senate,8,Voters,Under Vote,21,1,3,25
+Grand,2081325008,State Senate,8,Voters,Number of Ballots,350,104,94,548
+Grand,2081325008,State House,13,REP,Adam Ochs,199,66,46,311
+Grand,2081325008,State House,13,DEM,Claire Levy,94,22,31,147
+Grand,2081325008,State House,13,LBT,Howard P Lambert,17,8,8,33
+Grand,2081325008,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325008,State House,13,Voters,Under Vote,40,8,9,57
+Grand,2081325008,State House,13,Voters,Number of Ballots,350,104,94,548
+Grand,2081325009,State Senate,8,DEM,Emily Tracy,160,16,89,265
+Grand,2081325009,State Senate,8,REP,Randy L. Baumgardner,100,5,61,166
+Grand,2081325009,State Senate,8,LBT,Sacha L. Weis,15,1,7,23
+Grand,2081325009,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325009,State Senate,8,Voters,Under Vote,18,0,11,29
+Grand,2081325009,State Senate,8,Voters,Number of Ballots,293,22,168,483
+Grand,2081325009,State House,13,REP,Adam Ochs,98,5,49,152
+Grand,2081325009,State House,13,DEM,Claire Levy,156,14,95,265
+Grand,2081325009,State House,13,LBT,Howard P Lambert,15,2,7,24
+Grand,2081325009,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325009,State House,13,Voters,Under Vote,24,1,17,42
+Grand,2081325009,State House,13,Voters,Number of Ballots,293,22,168,483
+Grand,2081325010,State Senate,8,DEM,Emily Tracy,180,14,41,235
+Grand,2081325010,State Senate,8,REP,Randy L. Baumgardner,266,30,73,369
+Grand,2081325010,State Senate,8,LBT,Sacha L. Weis,10,1,2,13
+Grand,2081325010,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325010,State Senate,8,Voters,Under Vote,22,0,2,24
+Grand,2081325010,State Senate,8,Voters,Number of Ballots,478,45,118,641
+Grand,2081325010,State House,13,REP,Adam Ochs,253,29,65,347
+Grand,2081325010,State House,13,DEM,Claire Levy,183,13,44,240
+Grand,2081325010,State House,13,LBT,Howard P Lambert,11,2,5,18
+Grand,2081325010,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325010,State House,13,Voters,Under Vote,31,1,4,36
+Grand,2081325010,State House,13,Voters,Number of Ballots,478,45,118,641
+Grand,2081325011,State Senate,8,DEM,Emily Tracy,173,19,56,248
+Grand,2081325011,State Senate,8,REP,Randy L. Baumgardner,126,14,54,194
+Grand,2081325011,State Senate,8,LBT,Sacha L. Weis,26,0,9,35
+Grand,2081325011,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325011,State Senate,8,Voters,Under Vote,19,1,9,29
+Grand,2081325011,State Senate,8,Voters,Number of Ballots,344,34,128,506
+Grand,2081325011,State House,13,REP,Adam Ochs,124,13,49,186
+Grand,2081325011,State House,13,DEM,Claire Levy,172,18,57,247
+Grand,2081325011,State House,13,LBT,Howard P Lambert,19,0,12,31
+Grand,2081325011,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325011,State House,13,Voters,Under Vote,29,3,10,42
+Grand,2081325011,State House,13,Voters,Number of Ballots,344,34,128,506
+Grand,2081325012,State Senate,8,DEM,Emily Tracy,225,16,65,306
+Grand,2081325012,State Senate,8,REP,Randy L. Baumgardner,288,16,88,392
+Grand,2081325012,State Senate,8,LBT,Sacha L. Weis,17,4,7,28
+Grand,2081325012,State Senate,8,Voters,Over Vote,0,0,0,0
+Grand,2081325012,State Senate,8,Voters,Under Vote,27,0,19,46
+Grand,2081325012,State Senate,8,Voters,Number of Ballots,557,36,179,772
+Grand,2081325012,State House,13,REP,Adam Ochs,276,15,77,368
+Grand,2081325012,State House,13,DEM,Claire Levy,226,17,69,312
+Grand,2081325012,State House,13,LBT,Howard P Lambert,13,2,11,26
+Grand,2081325012,State House,13,Voters,Over Vote,0,0,0,0
+Grand,2081325012,State House,13,Voters,Under Vote,42,2,22,66
+Grand,2081325012,State House,13,Voters,Number of Ballots,557,36,179,772
+Grand,Prov,State Senate,8,DEM,Emily Tracy,,,62,"3,225"
+Grand,Prov,State Senate,8,REP,Randy L. Baumgardner,,,69,"4,224"
+Grand,Prov,State Senate,8,LBT,Sacha L. Weis,,,10,356
+Grand,Prov,State Senate,8,Voters,Over Vote,,,0,0
+Grand,Prov,State Senate,8,Voters,Under Vote,,,25,465
+Grand,Prov,State Senate,8,Voters,Number of Ballots,,,166,"8,270"
+Grand,Prov,State House,13,REP,Adam Ochs,,,58,"3,955"
+Grand,Prov,State House,13,DEM,Claire Levy,,,64,"3,239"
+Grand,Prov,State House,13,LBT,Howard P Lambert,,,15,393
+Grand,Prov,State House,13,Voters,Over Vote,,,0,0
+Grand,Prov,State House,13,Voters,Under Vote,,,29,683
+Grand,Prov,State House,13,Voters,Number of Ballots,,,166,"8,270"

--- a/2012/20121106__co__general__grand__precinct.csv
+++ b/2012/20121106__co__general__grand__precinct.csv
@@ -386,7 +386,7 @@ Grand,2081325003,State House,13,LBT,Howard P Lambert,29,5,24,58
 Grand,2081325003,State House,13,Voters,Over Vote,0,0,0,0
 Grand,2081325003,State House,13,Voters,Under Vote,62,5,23,90
 Grand,2081325003,State House,13,Voters,Number of Ballots,744,84,263,1091
-Grand,2081325003,State Senate,8,DEM,Emily Tracy,71,15,37,123
+Grand,2081325004,State Senate,8,DEM,Emily Tracy,71,15,37,123
 Grand,2081325004,State Senate,8,REP,Randy L. Baumgardner,206,27,119,352
 Grand,2081325004,State Senate,8,LBT,Sacha L. Weis,14,1,6,21
 Grand,2081325004,State Senate,8,Voters,Over Vote,0,0,0,0


### PR DESCRIPTION
This fixes an incorrect precinct that resulted in a duplicate entry.  According to the [source file](https://github.com/openelections/openelections-sources-co/blob/0e71c010ac12c60a5a0ff124a2ab8619e1309007/Grand/2012GRAND00804901.pdf), these values should be associated with precinct 2081325004:

![image](https://user-images.githubusercontent.com/17345532/132139416-e2c0f8c9-cd46-465a-a5cb-564cb8c3722e.png)

This also fixes the line endings.  The actual precinct change is contained in revision 3e4e171c2eba9a3d873879d6f6a0837d3846190f.
