### PR TITLE
Fix amendment "candidate" in 2012 San Miguel County general file

### DIFF
--- a/2012/20121106__co__general__san_miguel__precinct.csv
+++ b/2012/20121106__co__general__san_miguel__precinct.csv
@@ -1,1 +1,121 @@
-county,precinct,office,district,party,candidate,votesSan Miguel,1,President,,AC,Virgil Goode,2San Miguel,2,President,,AC,Virgil Goode,0San Miguel,3,President,,AC,Virgil Goode,0San Miguel,4,President,,AC,Virgil Goode,7San Miguel,5,President,,AC,Virgil Goode,0San Miguel,6,President,,AC,Virgil Goode,3San Miguel,1 City of Telluride,President,,D,Barack Obama,1214San Miguel,2 Rural Telluride,President,,D,Barack Obama,786San Miguel,3 Placerville,President,,D,Barack Obama,360San Miguel,4 Norwood,President,,D,Barack Obama,326San Miguel,5 Slickrock vbm,President,,D,Barack Obama,17San Miguel,6 Mtn Village,President,,D,Barack Obama,289San Miguel,1,President,,R,Mitt Romney,236San Miguel,2,President,,R,Mitt Romney,186San Miguel,3,President,,R,Mitt Romney,131San Miguel,4,President,,R,Mitt Romney,402San Miguel,5,President,,R,Mitt Romney,60San Miguel,6,President,,R,Mitt Romney,139San Miguel,1,President,,L,Gary Johnson,19San Miguel,2,President,,L,Gary Johnson,11San Miguel,3,President,,L,Gary Johnson,7San Miguel,4,President,,L,Gary Johnson,9San Miguel,5,President,,L,Gary Johnson,1San Miguel,6,President,,L,Gary Johnson,5San Miguel,1,President,,G,Jill Stein,14San Miguel,2,President,,G,Jill Stein,4San Miguel,3,President,,G,Jill Stein,3San Miguel,4,President,,G,Jill Stein,3San Miguel,5,President,,G,Jill Stein,0San Miguel,6,President,,G,Jill Stein,7San Miguel,1,President,,S,Stewart Alexander,0San Miguel,2,President,,S,Stewart Alexander,0San Miguel,3,President,,S,Stewart Alexander,1San Miguel,4,President,,S,Stewart Alexander,0San Miguel,5,President,,S,Stewart Alexander,0San Miguel,6,President,,S,Stewart Alexander,0San Miguel,1,President,,J,Ross Anderson,1San Miguel,2,President,,J,Ross Anderson,1San Miguel,3,President,,J,Ross Anderson,0San Miguel,4,President,,J,Ross Anderson,1San Miguel,5,President,,J,Ross Anderson,0San Miguel,6,President,,J,Ross Anderson,0San Miguel,1 City of Telluride,President,,PFP,Roseanne Barr,3San Miguel,2 Rural Telluride,President,,PFP,Roseanne Barr,1San Miguel,3 Placerville,President,,PFP,Roseanne Barr,0San Miguel,4 Norwood,President,,PFP,Roseanne Barr,3San Miguel,5 Slickrock vbm,President,,PFP,Roseanne Barr,0San Miguel,6 Mtn Village,President,,PFP,Roseanne Barr,0San Miguel,1,President,,SW,James Harris,1San Miguel,2,President,,SW,James Harris,0San Miguel,3,President,,SW,James Harris,0San Miguel,4,President,,SW,James Harris,0San Miguel,5,President,,SW,James Harris,0San Miguel,6,President,,SW,James Harris,0San Miguel,1,President,,U,Jill Reed,0San Miguel,2,President,,U,Jill Reed,0San Miguel,3,President,,U,Jill Reed,0San Miguel,4,President,,U,Jill Reed,1San Miguel,5,President,,U,Jill Reed,1San Miguel,6,President,,U,Jill Reed,0San Miguel,1,President,,WTP,Sheila Tittle,1San Miguel,2,President,,WTP,Sheila Tittle,0San Miguel,3,President,,WTP,Sheila Tittle,0San Miguel,4,President,,WTP,Sheila Tittle,0San Miguel,5,President,,WTP,Sheila Tittle,0San Miguel,6,President,,WTP,Sheila Tittle,0San Miguel,1 City of Telluride,U.S. House,3,D,Sal Pace,1104San Miguel,2 Rural Telluride,U.S. House,3,D,Sal Pace,714San Miguel,3 Placerville,U.S. House,3,D,Sal Pace,332San Miguel,4 Norwood,U.S. House,3,D,Sal Pace,296San Miguel,5 Slickrock vbm,U.S. House,3,D,Sal Pace,11San Miguel,6 Mtn Village,U.S. House,3,D,Sal Pace,266San Miguel,1 City of Telluride,U.S. House,3,R,Scott Tipton,235San Miguel,2 Rural Telluride,U.S. House,3,R,Scott Tipton,187San Miguel,3 Placerville,U.S. House,3,R,Scott Tipton,136San Miguel,4 Norwood,U.S. House,3,R,Scott Tipton,402San Miguel,5 Slickrock vbm,U.S. House,3,R,Scott Tipton,61San Miguel,6 Mtn Village,U.S. House,3,R,Scott Tipton,132San Miguel,1 City of Telluride,U.S. House,3,L,Gregory Gilman,63San Miguel,2 Rural Telluride,U.S. House,3,L,Gregory Gilman,23San Miguel,3 Placerville,U.S. House,3,L,Gregory Gilman,19San Miguel,4 Norwood,U.S. House,3,L,Gregory Gilman,23San Miguel,5 Slickrock vbm,U.S. House,3,L,Gregory Gilman,3San Miguel,6 Mtn Village,U.S. House,3,L,Gregory Gilman,20San Miguel,1 City of Telluride,U.S. House,3,U,Tisha Casida,22San Miguel,2 Rural Telluride,U.S. House,3,U,Tisha Casida,17San Miguel,3 Placerville,U.S. House,3,U,Tisha Casida,4San Miguel,4 Norwood,U.S. House,3,U,Tisha Casida,16San Miguel,5 Slickrock vbm,U.S. House,3,U,Tisha Casida,3San Miguel,6 Mtn Village,U.S. House,3,U,Tisha Casida,10San Miguel,1 City of Telluride,State House,58,D,Tammy Theis,929San Miguel,2 Rural Telluride,State House,58,D,Tammy Theis,604San Miguel,3 Placerville,State House,58,D,Tammy Theis,278San Miguel,4 Norwood,State House,58,D,Tammy Theis,236San Miguel,5 Slickrock vbm,State House,58,D,Tammy Theis,11San Miguel,6 Mtn Village,State House,58,D,Tammy Theis,234San Miguel,1 City of Telluride,State House,58,R,Don Coram,227San Miguel,2 Rural Telluride,State House,58,R,Don Coram,184San Miguel,3 Placerville,State House,58,R,Don Coram,133San Miguel,4 Norwood,State House,58,R,Don Coram,404San Miguel,5 Slickrock vbm,State House,58,R,Don Coram,58San Miguel,6 Mtn Village,State House,58,R,Don Coram,132San Miguel,1 City of Telluride,State House,58,L,Jeff Downs,153San Miguel,2 Rural Telluride,State House,58,L,Jeff Downs,79San Miguel,3 Placerville,State House,58,L,Jeff Downs,41San Miguel,4 Norwood,State House,58,L,Jeff Downs,59San Miguel,5 Slickrock vbm,State House,58,L,Jeff Downs,3San Miguel,6 Mtn Village,State House,58,L,Jeff Downs,42San Miguel,1 City of Telluride,Amendment,64,,Yes,1284San Miguel,2 Rural Telluride,Amendment,64,,Yes,792San Miguel,3 Placerville,Amendment,64,,Yes,401San Miguel,4 Norwood,Amendment,64,,Yes,445San Miguel,5 Slickrock vbm,Amendment,64,,Yes,34San Miguel,6 Mtn Village,Amendment,64,,Yes,339San Miguel,1 City of Telluride,Amendment,64,,Yes,169San Miguel,2 Rural Telluride,Amendment,64,,Yes,178San Miguel,3 Placerville,Amendment,64,,Yes,94San Miguel,4 Norwood,Amendment,64,,Yes,293San Miguel,5 Slickrock vbm,Amendment,64,,Yes,41San Miguel,6 Mtn Village,Amendment,64,,Yes,91
+county,precinct,office,district,party,candidate,votes
+San Miguel,1,President,,AC,Virgil Goode,2
+San Miguel,2,President,,AC,Virgil Goode,0
+San Miguel,3,President,,AC,Virgil Goode,0
+San Miguel,4,President,,AC,Virgil Goode,7
+San Miguel,5,President,,AC,Virgil Goode,0
+San Miguel,6,President,,AC,Virgil Goode,3
+San Miguel,1 City of Telluride,President,,D,Barack Obama,1214
+San Miguel,2 Rural Telluride,President,,D,Barack Obama,786
+San Miguel,3 Placerville,President,,D,Barack Obama,360
+San Miguel,4 Norwood,President,,D,Barack Obama,326
+San Miguel,5 Slickrock vbm,President,,D,Barack Obama,17
+San Miguel,6 Mtn Village,President,,D,Barack Obama,289
+San Miguel,1,President,,R,Mitt Romney,236
+San Miguel,2,President,,R,Mitt Romney,186
+San Miguel,3,President,,R,Mitt Romney,131
+San Miguel,4,President,,R,Mitt Romney,402
+San Miguel,5,President,,R,Mitt Romney,60
+San Miguel,6,President,,R,Mitt Romney,139
+San Miguel,1,President,,L,Gary Johnson,19
+San Miguel,2,President,,L,Gary Johnson,11
+San Miguel,3,President,,L,Gary Johnson,7
+San Miguel,4,President,,L,Gary Johnson,9
+San Miguel,5,President,,L,Gary Johnson,1
+San Miguel,6,President,,L,Gary Johnson,5
+San Miguel,1,President,,G,Jill Stein,14
+San Miguel,2,President,,G,Jill Stein,4
+San Miguel,3,President,,G,Jill Stein,3
+San Miguel,4,President,,G,Jill Stein,3
+San Miguel,5,President,,G,Jill Stein,0
+San Miguel,6,President,,G,Jill Stein,7
+San Miguel,1,President,,S,Stewart Alexander,0
+San Miguel,2,President,,S,Stewart Alexander,0
+San Miguel,3,President,,S,Stewart Alexander,1
+San Miguel,4,President,,S,Stewart Alexander,0
+San Miguel,5,President,,S,Stewart Alexander,0
+San Miguel,6,President,,S,Stewart Alexander,0
+San Miguel,1,President,,J,Ross Anderson,1
+San Miguel,2,President,,J,Ross Anderson,1
+San Miguel,3,President,,J,Ross Anderson,0
+San Miguel,4,President,,J,Ross Anderson,1
+San Miguel,5,President,,J,Ross Anderson,0
+San Miguel,6,President,,J,Ross Anderson,0
+San Miguel,1 City of Telluride,President,,PFP,Roseanne Barr,3
+San Miguel,2 Rural Telluride,President,,PFP,Roseanne Barr,1
+San Miguel,3 Placerville,President,,PFP,Roseanne Barr,0
+San Miguel,4 Norwood,President,,PFP,Roseanne Barr,3
+San Miguel,5 Slickrock vbm,President,,PFP,Roseanne Barr,0
+San Miguel,6 Mtn Village,President,,PFP,Roseanne Barr,0
+San Miguel,1,President,,SW,James Harris,1
+San Miguel,2,President,,SW,James Harris,0
+San Miguel,3,President,,SW,James Harris,0
+San Miguel,4,President,,SW,James Harris,0
+San Miguel,5,President,,SW,James Harris,0
+San Miguel,6,President,,SW,James Harris,0
+San Miguel,1,President,,U,Jill Reed,0
+San Miguel,2,President,,U,Jill Reed,0
+San Miguel,3,President,,U,Jill Reed,0
+San Miguel,4,President,,U,Jill Reed,1
+San Miguel,5,President,,U,Jill Reed,1
+San Miguel,6,President,,U,Jill Reed,0
+San Miguel,1,President,,WTP,Sheila Tittle,1
+San Miguel,2,President,,WTP,Sheila Tittle,0
+San Miguel,3,President,,WTP,Sheila Tittle,0
+San Miguel,4,President,,WTP,Sheila Tittle,0
+San Miguel,5,President,,WTP,Sheila Tittle,0
+San Miguel,6,President,,WTP,Sheila Tittle,0
+San Miguel,1 City of Telluride,U.S. House,3,D,Sal Pace,1104
+San Miguel,2 Rural Telluride,U.S. House,3,D,Sal Pace,714
+San Miguel,3 Placerville,U.S. House,3,D,Sal Pace,332
+San Miguel,4 Norwood,U.S. House,3,D,Sal Pace,296
+San Miguel,5 Slickrock vbm,U.S. House,3,D,Sal Pace,11
+San Miguel,6 Mtn Village,U.S. House,3,D,Sal Pace,266
+San Miguel,1 City of Telluride,U.S. House,3,R,Scott Tipton,235
+San Miguel,2 Rural Telluride,U.S. House,3,R,Scott Tipton,187
+San Miguel,3 Placerville,U.S. House,3,R,Scott Tipton,136
+San Miguel,4 Norwood,U.S. House,3,R,Scott Tipton,402
+San Miguel,5 Slickrock vbm,U.S. House,3,R,Scott Tipton,61
+San Miguel,6 Mtn Village,U.S. House,3,R,Scott Tipton,132
+San Miguel,1 City of Telluride,U.S. House,3,L,Gregory Gilman,63
+San Miguel,2 Rural Telluride,U.S. House,3,L,Gregory Gilman,23
+San Miguel,3 Placerville,U.S. House,3,L,Gregory Gilman,19
+San Miguel,4 Norwood,U.S. House,3,L,Gregory Gilman,23
+San Miguel,5 Slickrock vbm,U.S. House,3,L,Gregory Gilman,3
+San Miguel,6 Mtn Village,U.S. House,3,L,Gregory Gilman,20
+San Miguel,1 City of Telluride,U.S. House,3,U,Tisha Casida,22
+San Miguel,2 Rural Telluride,U.S. House,3,U,Tisha Casida,17
+San Miguel,3 Placerville,U.S. House,3,U,Tisha Casida,4
+San Miguel,4 Norwood,U.S. House,3,U,Tisha Casida,16
+San Miguel,5 Slickrock vbm,U.S. House,3,U,Tisha Casida,3
+San Miguel,6 Mtn Village,U.S. House,3,U,Tisha Casida,10
+San Miguel,1 City of Telluride,State House,58,D,Tammy Theis,929
+San Miguel,2 Rural Telluride,State House,58,D,Tammy Theis,604
+San Miguel,3 Placerville,State House,58,D,Tammy Theis,278
+San Miguel,4 Norwood,State House,58,D,Tammy Theis,236
+San Miguel,5 Slickrock vbm,State House,58,D,Tammy Theis,11
+San Miguel,6 Mtn Village,State House,58,D,Tammy Theis,234
+San Miguel,1 City of Telluride,State House,58,R,Don Coram,227
+San Miguel,2 Rural Telluride,State House,58,R,Don Coram,184
+San Miguel,3 Placerville,State House,58,R,Don Coram,133
+San Miguel,4 Norwood,State House,58,R,Don Coram,404
+San Miguel,5 Slickrock vbm,State House,58,R,Don Coram,58
+San Miguel,6 Mtn Village,State House,58,R,Don Coram,132
+San Miguel,1 City of Telluride,State House,58,L,Jeff Downs,153
+San Miguel,2 Rural Telluride,State House,58,L,Jeff Downs,79
+San Miguel,3 Placerville,State House,58,L,Jeff Downs,41
+San Miguel,4 Norwood,State House,58,L,Jeff Downs,59
+San Miguel,5 Slickrock vbm,State House,58,L,Jeff Downs,3
+San Miguel,6 Mtn Village,State House,58,L,Jeff Downs,42
+San Miguel,1 City of Telluride,Amendment,64,,Yes,1284
+San Miguel,2 Rural Telluride,Amendment,64,,Yes,792
+San Miguel,3 Placerville,Amendment,64,,Yes,401
+San Miguel,4 Norwood,Amendment,64,,Yes,445
+San Miguel,5 Slickrock vbm,Amendment,64,,Yes,34
+San Miguel,6 Mtn Village,Amendment,64,,Yes,339
+San Miguel,1 City of Telluride,Amendment,64,,Yes,169
+San Miguel,2 Rural Telluride,Amendment,64,,Yes,178
+San Miguel,3 Placerville,Amendment,64,,Yes,94
+San Miguel,4 Norwood,Amendment,64,,Yes,293
+San Miguel,5 Slickrock vbm,Amendment,64,,Yes,41
+San Miguel,6 Mtn Village,Amendment,64,,Yes,91

--- a/2012/20121106__co__general__san_miguel__precinct.csv
+++ b/2012/20121106__co__general__san_miguel__precinct.csv
@@ -113,9 +113,9 @@ San Miguel,3 Placerville,Amendment,64,,Yes,401
 San Miguel,4 Norwood,Amendment,64,,Yes,445
 San Miguel,5 Slickrock vbm,Amendment,64,,Yes,34
 San Miguel,6 Mtn Village,Amendment,64,,Yes,339
-San Miguel,1 City of Telluride,Amendment,64,,Yes,169
-San Miguel,2 Rural Telluride,Amendment,64,,Yes,178
-San Miguel,3 Placerville,Amendment,64,,Yes,94
-San Miguel,4 Norwood,Amendment,64,,Yes,293
-San Miguel,5 Slickrock vbm,Amendment,64,,Yes,41
-San Miguel,6 Mtn Village,Amendment,64,,Yes,91
+San Miguel,1 City of Telluride,Amendment,64,,No,169
+San Miguel,2 Rural Telluride,Amendment,64,,No,178
+San Miguel,3 Placerville,Amendment,64,,No,94
+San Miguel,4 Norwood,Amendment,64,,No,293
+San Miguel,5 Slickrock vbm,Amendment,64,,No,41
+San Miguel,6 Mtn Village,Amendment,64,,No,91


### PR DESCRIPTION
This fixes some `candidate` entries that resulted in duplicate entries.  According to the [source file](https://github.com/openelections/openelections-sources-co/blob/0e71c010ac12c60a5a0ff124a2ab8619e1309007/San%20Miguel/2012_general.xls), these entries correspond to "No" votes for Amendment 64:

![image](https://user-images.githubusercontent.com/17345532/132139689-ceb95127-644d-4486-ae5b-860eaedeb618.png)

This also fixes the line endings.  The actual change is contained in revision ea6cccc91430b21919450f420d65277851f74f32.