### PR TITLE
Fix incorrect ballot issue in 2018 Douglas County general file

### DIFF
--- a/2018/20181106__co__general__douglas__precinct.csv
+++ b/2018/20181106__co__general__douglas__precinct.csv
@@ -1364,9 +1364,9 @@ Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,308
 Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,573
 Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5B,,Total,881
-Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,49
-Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,28
-Douglas,Precinct 401,Douglas County School District RE-1 Ballot Issue 5B,,Total,77
+Douglas,Precinct 401,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,49
+Douglas,Precinct 401,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,28
+Douglas,Precinct 401,Larkspur Fire Protection District Ballot Issue 6B,,Total,77
 Douglas,Precinct 402,U.S. House,4,Karen McCormick,221
 Douglas,Precinct 402,U.S. House,4,Ken Buck,502
 Douglas,Precinct 402,U.S. House,4,Write-in,(< 25)
@@ -1516,9 +1516,9 @@ Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,240
 Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,460
 Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5B,,Total,700
-Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,29
-Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,(< 25)
-Douglas,Precinct 402,Douglas County School District RE-1 Ballot Issue 5B,,Total,33
+Douglas,Precinct 402,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,29
+Douglas,Precinct 402,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,(< 25)
+Douglas,Precinct 402,Larkspur Fire Protection District Ballot Issue 6B,,Total,33
 Douglas,Precinct 403,U.S. House,4,Karen McCormick,54
 Douglas,Precinct 403,U.S. House,4,Ken Buck,124
 Douglas,Precinct 403,U.S. House,4,Write-in,0
@@ -1823,9 +1823,9 @@ Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,510
 Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,820
 Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5B,,Total,1330
-Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,1078
-Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,259
-Douglas,Precinct 404,Douglas County School District RE-1 Ballot Issue 5B,,Total,1337
+Douglas,Precinct 404,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,1078
+Douglas,Precinct 404,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,259
+Douglas,Precinct 404,Larkspur Fire Protection District Ballot Issue 6B,,Total,1337
 Douglas,Precinct 405,U.S. House,4,Karen McCormick,408
 Douglas,Precinct 405,U.S. House,4,Ken Buck,873
 Douglas,Precinct 405,U.S. House,4,Write-in,(< 25)
@@ -1975,9 +1975,9 @@ Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,427
 Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,859
 Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5B,,Total,1286
-Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,919
-Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,369
-Douglas,Precinct 405,Douglas County School District RE-1 Ballot Issue 5B,,Total,1288
+Douglas,Precinct 405,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,919
+Douglas,Precinct 405,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,369
+Douglas,Precinct 405,Larkspur Fire Protection District Ballot Issue 6B,,Total,1288
 Douglas,Precinct 406,U.S. House,4,Karen McCormick,201
 Douglas,Precinct 406,U.S. House,4,Ken Buck,476
 Douglas,Precinct 406,U.S. House,4,Write-in,0
@@ -2127,9 +2127,9 @@ Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,194
 Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,474
 Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5B,,Total,668
-Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,475
-Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,190
-Douglas,Precinct 406,Douglas County School District RE-1 Ballot Issue 5B,,Total,665
+Douglas,Precinct 406,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,475
+Douglas,Precinct 406,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,190
+Douglas,Precinct 406,Larkspur Fire Protection District Ballot Issue 6B,,Total,665
 Douglas,Precinct 508,U.S. House,4,Karen McCormick,386
 Douglas,Precinct 508,U.S. House,4,Ken Buck,1014
 Douglas,Precinct 508,U.S. House,4,Write-in,(< 25)
@@ -2428,9 +2428,9 @@ Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,279
 Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,577
 Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5B,,Total,856
-Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,186
-Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,117
-Douglas,Precinct 511,Douglas County School District RE-1 Ballot Issue 5B,,Total,303
+Douglas,Precinct 511,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,186
+Douglas,Precinct 511,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,117
+Douglas,Precinct 511,Larkspur Fire Protection District Ballot Issue 6B,,Total,303
 Douglas,Precinct 512,U.S. House,4,Karen McCormick,266
 Douglas,Precinct 512,U.S. House,4,Ken Buck,855
 Douglas,Precinct 512,U.S. House,4,Write-in,(< 25)
@@ -2580,9 +2580,9 @@ Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,268
 Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,836
 Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5B,,Total,1104
-Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,252
-Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,176
-Douglas,Precinct 512,Douglas County School District RE-1 Ballot Issue 5B,,Total,428
+Douglas,Precinct 512,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,252
+Douglas,Precinct 512,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,176
+Douglas,Precinct 512,Larkspur Fire Protection District Ballot Issue 6B,,Total,428
 Douglas,Precinct 302,U.S. House,4,Karen McCormick,702
 Douglas,Precinct 302,U.S. House,4,Ken Buck,661
 Douglas,Precinct 302,U.S. House,4,Write-in,(< 25)
@@ -13715,9 +13715,9 @@ Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5A,,Total,
 Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,809
 Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,941
 Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5B,,Total,1750
-Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5B,,Yes/For,0
-Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5B,,No/Against,0
-Douglas,Precinct 510,Douglas County School District RE-1 Ballot Issue 5B,,Total,0
+Douglas,Precinct 510,Larkspur Fire Protection District Ballot Issue 6B,,Yes/For,0
+Douglas,Precinct 510,Larkspur Fire Protection District Ballot Issue 6B,,No/Against,0
+Douglas,Precinct 510,Larkspur Fire Protection District Ballot Issue 6B,,Total,0
 Douglas,Precinct 513,U.S. House,4,Karen McCormick,478
 Douglas,Precinct 513,U.S. House,4,Ken Buck,731
 Douglas,Precinct 513,U.S. House,4,Write-in,(< 25)


### PR DESCRIPTION
This fixes some incorrect ballot issues in the 2018 Douglas County general file.  According to [this source](https://www.douglas.co.us/documents/2018-general-election-county-wide-official-precinct-report.pdf/), these entries are associated with ballot issue 6B.  For example, 

![image](https://user-images.githubusercontent.com/17345532/132378451-cdc9f871-db67-4167-b72b-fe2a87c5e6f6.png)
